### PR TITLE
Be nicer to visitors of the GitHub repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,11 @@
+Specification of Regions of Interest for scientific data analysis
+=================================================================
+
+This repository contains the specification in ReStructuredText format.
+The current specification can be seen on the `SciJava website
+<http://www.scijava.org/roi-model/>`_.
+
+If you want to rebuild the specification from scratch, you need to install
+sphinx, python, graphviz, texlive (on Debian-based systems, please call ``sudo
+apt-get install sphinx-common python graphviz texlive``). Then simply run
+``make``.


### PR DESCRIPTION
On GitHub, the README is rendered on the default page of the
repository. Rather than leave the occasional visitor puzzled what to
do with this repository, we should give them a hint where they can
see the current specification, and how they can build it themselves
from scratch.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
